### PR TITLE
feat: add June 4th spell addresses

### DIFF
--- a/src/Avalanche.sol
+++ b/src/Avalanche.sol
@@ -35,8 +35,9 @@ library Avalanche {
     /*** Governance Relay Addresses                                                                                 ***/
     /******************************************************************************************************************/
 
-    address internal constant GROVE_EXECUTOR = 0x4b803781828b76EaBF21AaF02e5ce23596b4d60c;
-    address internal constant GROVE_RECEIVER = 0x26e9512547feC1906C55256e491DfB6673D8C23f;
+    address internal constant GROVE_EXECUTOR         = 0x4b803781828b76EaBF21AaF02e5ce23596b4d60c;
+    address internal constant GROVE_CCTP_V1_RECEIVER = 0x26e9512547feC1906C55256e491DfB6673D8C23f;
+    address internal constant GROVE_CCTP_V2_RECEIVER = 0x8Ea8Dff8c29f568eA1E716E2C3AfbD003EB83cfA;
 
     /******************************************************************************************************************/
     /*** Centrifuge Addresses                                                                                       ***/

--- a/src/Ethereum.sol
+++ b/src/Ethereum.sol
@@ -55,6 +55,8 @@ library Ethereum {
     address internal constant PSM         = 0xf6e72Db5454dd049d0788e411b06CfAF16853042;  // Lite PSM
     address internal constant VAT         = 0x35D1b3F3D7966A1DFe207aa4514C12a259A0492B;
 
+    address internal constant WRAPPER_USDS_LITE_PSM_USDC_A = 0xA188EEC8F81263234dA3622A406892F3D630f98c;
+
     /******************************************************************************************************************/
     /*** GroveDAO Addresses                                                                                         ***/
     /******************************************************************************************************************/


### PR DESCRIPTION
On purpose renamed `GROVE_RECEIVER` to `GROVE_CCTP_V1_RECEIVER` so "default" `GROVE_RECEIVER` is removed from the registry. When pulling this registry update, there a forced decision to move to V2 or deliberately stay at V1.